### PR TITLE
Resolve a memory leak

### DIFF
--- a/lib/cartoRenderer.js
+++ b/lib/cartoRenderer.js
@@ -52,14 +52,14 @@ var renderImage = exports.renderImage = function(options) {
 
   // once upon a time, we used to scale and translate the canvas instead of transforming the points.
   // However, this causes problems when drawing images and patterns, so we can't do that anymore :(
-  transform = function(p) {
+  function transform(p) {
     var point = [];
     point[0] = (p[0] - bounds.minX) * pxPtRatio;
     point[1] = ((p[1] - bounds.minY) * -pxPtRatio) + height;
     return point;
   };
 
-  cartoImageRenderer(ctx, pxPtRatio, options.layers, options.styles, options.zoom, bounds.minX, bounds.maxX, bounds.minY);
+  cartoImageRenderer(ctx, pxPtRatio, options.layers, options.styles, options.zoom, bounds.minX, bounds.maxX, bounds.minY, transform);
 
   // console.log("Rendered image in " + (Date.now() - start) + "ms");
 
@@ -87,7 +87,7 @@ var renderGrid = exports.renderGrid = function(options) {
     return;
   }
 
-  transform = function(p) {
+  function transform(p) {
     var point = [];
     point[0] = (p[0] - bounds.minX) * pxPtRatio;
     point[1] = ((p[1] - bounds.minY) * -pxPtRatio) + height;
@@ -103,7 +103,7 @@ var renderGrid = exports.renderGrid = function(options) {
 
   // TODO: what is going on here?
   // renderer is provided somehow (but we'll have a simple default)
-  var colorIndex = cartoGridRenderer(ctx, pxPtRatio, options.layers, options.styles, options.zoom);
+  var colorIndex = cartoGridRenderer(ctx, pxPtRatio, options.layers, options.styles, options.zoom, transform);
 
   var delegate = function delegate(point) {
     // Use our raster (ctx) and colorIndex to lookup the corresponding feature
@@ -135,474 +135,222 @@ var renderGrid = exports.renderGrid = function(options) {
 // Functions to render paths for different geometries
 // NB:- these functions are called using 'this' as our canvas context
 // it's not clear to me whether this architecture is right but it's neat ATM.
-var transform = null;
-var renderPath = {
+function makeRenderers(transform) {
+  var renderPath = {
 
-  'MultiPolygon': function(mp) {
-    for (var i = mp.length - 1; i >= 0; i--) {
-      renderPath.Polygon.call(this, mp[i]);
-    }
-  },
+    'MultiPolygon': function(mp) {
+      for (var i = mp.length - 1; i >= 0; i--) {
+        renderPath.Polygon.call(this, mp[i]);
+      }
+    },
 
-  'Polygon': function(p) {
-    for (var i = p.length - 1; i >= 0; i--) {
-      renderPath.LineString.call(this, p[i]);
-    }
-  },
+    'Polygon': function(p) {
+      for (var i = p.length - 1; i >= 0; i--) {
+        renderPath.LineString.call(this, p[i]);
+      }
+    },
 
-  'MultiLineString': function(ml) {
-    ml.forEach(renderPath.LineString, this);
-  },
+    'MultiLineString': function(ml) {
+      ml.forEach(renderPath.LineString, this);
+    },
 
-  'LineString': function(l) {
-    // Figure out where we need to start at
-    var start = l[0];
-    if (transform) {
-      start = transform(start);
-    }
-    this.moveTo(start[0], start[1]);
-
-    // Make a new array with just the remaining vertices
-    // (equivalent to x[1:] in python)
-    var i;
-    var rest = Array(l.length - 1);
-    for (i = 0; i < rest.length; i++) {
-      rest[i] = l[i + 1];
-    }
-
-    // draw the shape
-    for (i = 0; i < rest.length; i++) {
+    'LineString': function(l) {
+      // Figure out where we need to start at
+      var start = l[0];
       if (transform) {
-        rest[i] = transform(rest[i]);
+        start = transform(start);
       }
-      this.lineTo(rest[i][0], rest[i][1]);
-    }
-  },
+      this.moveTo(start[0], start[1]);
 
-  'MultiPoint': function(p, scale) {
-    // Can't use forEach here because we need to pass scale along
-    for (var i = 0, len = p.length; i < len; i++) {
-      renderPath.Point.call(this, p[i], scale);
-    }
-  },
-
-  'Point': function(p, scale) {
-    if (transform) {
-      p = transform(p);
-      this.arc(p[0], p[1], 8, 0, Math.PI * 2, true);
-    }
-    else {
-      this.arc(p[0], p[1], 8 / scale, 0, Math.PI * 2, true);
-    }
-  }
-};
-
-// TODO: where / why do we use this?
-var roundPoint = function(point) {
-  return point.map(Math.round);
-};
-
-// Functions to render dashed lines
-// Many canvas implementations don't support the dash/lineDash property, so we do it by hand :\
-// NOTE also lineDash is in the WHATWG HTML draft but not W3C:
-// http://www.whatwg.org/specs/web-apps/current-work/multipage/the-canvas-element.html
-var renderDashedPath = {
-  'MultiPolygon': function(dashArray, mp) {
-    mp.forEach(renderDashedPath.Polygon.bind(this, dashArray));
-  },
-  'Polygon': function(dashArray, p) {
-    p.forEach(renderDashedPath.LineString.bind(this, dashArray));
-  },
-  'MultiLineString': function(dashArray, ml) {
-    ml.forEach(renderDashedPath.LineString.bind(this, dashArray));
-  },
-
-  'LineString': function(dashArray, l, offset) {
-    // if there's no dashArray, just go render a solid line
-    if (!dashArray) {
-      return renderPath.LineString.call(this, l);
-    }
-
-    offset = offset || 0;
-
-    // don't render segments less than this length (in px)
-    // for best fidelity, this should be at least 1, but not much higher
-    var minSegmentLength = 2;
-
-    // round off the start and end points to get as close as we can to drawing on pixel boundaries
-    // loop through line combining segments until they match the minimum length
-    var start = roundPoint(transform(l[0]));
-    for (var i = 1, len = l.length; i < len; i++) {
-      var end = roundPoint(transform(l[i])),
-          dx = end[0] - start[0];
-          dy = end[1] - start[1];
-          lineLength = Math.sqrt(dx * dx + dy * dy);
-
-      // only draw segments of 1px or greater
-      if (lineLength >= minSegmentLength) {
-        var angle = Math.atan2(dy, dx);
-        offset = renderDashedPath._screenLine.call(this, dashArray, start, end, lineLength, angle, offset);
-        start = end;
-      }
-    }
-
-  },
-
-  // TODO: What does this do?
-  _screenLine: function(dashArray, start, end, realLength, angle, offset) {
-    // we're gonna do some transforms
-    this.save();
-
-    // move the line out by half a pixel for more crisp 1px drawing
-    var yOffset = -0.5;
-
-    // In order to reduce artifacts of trying to draw fractions of a pixel,
-    // only draw even pixels worth of length
-    var length = Math.floor(realLength);
-
-    // Skip zero length/less-than-one length lines
-    if (length === 0) {
-      return offset;
-    }
-
-    // decimal offset is left over from refraining from drawing fractions of a pixel on a previous segment
-    // (see where the length is floor()'d above)
-    // We'll eventually move the start point back by the fractional offset to account for what we
-    // didn't draw in the previous segment (we potentially underdraw because we floor()'d the length).
-    var intOffset = Math.ceil(offset);
-    var decOffset = offset - intOffset;
-    offset = intOffset;
-
-    // transform the context so we can simplify the work by pretending to draw a straight line
-    this.translate(start[0], start[1]);
-    this.rotate(angle);
-
-    // Move the start point back by the fractional offset (see deeper description above)
-    this.moveTo(decOffset, yOffset);
-
-    var dashCount = dashArray.length;
-    var dashIndex = 0;
-    // Move the start point by the integer offset (the fractional bit is already accounted for above)
-    var x = offset || 0;
-    // keep track of how much of the pattern we drew (used to offset the next segment)
-    var patternDistance = 0;
-    var draw = true;
-
-    while (x < length) {
-      // reset the pattern distance when we loop back to the start of the dash array
-      if (dashIndex === 0) {
-        patternDistance = 0;
+      // Make a new array with just the remaining vertices
+      // (equivalent to x[1:] in python)
+      var i;
+      var rest = Array(l.length - 1);
+      for (i = 0; i < rest.length; i++) {
+        rest[i] = l[i + 1];
       }
 
-      // get the distance of this dash
-      var dashLength = dashArray[dashIndex];
-      dashIndex = (dashIndex + 1) % dashCount;
-      x += dashLength;
-      patternDistance += dashLength;
-
-      // if we are about to draw past the end of the segment, don't
-      if (x > length) {
-        patternDistance += length - x;
-        x = length;
-      }
-
-      // only draw once we've moved past the offset
-      if (x > 0) {
-        if (draw) {
-          this.lineTo(x, yOffset);
+      // draw the shape
+      for (i = 0; i < rest.length; i++) {
+        if (transform) {
+          rest[i] = transform(rest[i]);
         }
-        else {
-          this.moveTo(x, yOffset);
-        }
+        this.lineTo(rest[i][0], rest[i][1]);
       }
-      draw = !draw;
-    }
-    // Add the fractional extra distance that we didn't draw back in
-    patternDistance += realLength - length;
+    },
 
-    this.restore();
-    return -patternDistance;
-  },
-  'MultiPoint': function(dashArray, p, scale) {
-    // Can't use forEach here because we need to pass scale along
-    for (var i = 0, len = p.length; i < len; i++) {
-      renderDashedPath.Point.call(this, null, p[i], scale);
-    }
-  },
-  'Point': function(dashArray, p, scale) {
-    if (transform) {
-      p = transform(p);
-      this.arc(p[0], p[1], 8, 0, Math.PI * 2, true);
-    }
-    else {
-      this.arc(p[0], p[1], 8 / scale, 0, Math.PI * 2, true);
-    }
-  }
-};
+    'MultiPoint': function(p, scale) {
+      // Can't use forEach here because we need to pass scale along
+      for (var i = 0, len = p.length; i < len; i++) {
+        renderPath.Point.call(this, p[i], scale);
+      }
+    },
 
-var renderImage = {
-  'MultiPolygon': function(image, mp) {
-    mp.forEach(renderImage.Polygon.bind(this, image));
-  },
-  'Polygon': function(image, p) {
-    renderImage.LineString.call(this, image, p[0]);
-  },
-  'MultiLineString': function(image, ml) {
-    ml.forEach(renderImage.LineString.bind(this, image));
-  },
-  'LineString': function(image, l) {
-    // put the point at the center
-    var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-    l.forEach(function(point) {
-      minX = Math.min(minX, point[0]);
-      minY = Math.min(minY, point[1]);
-      maxX = Math.max(maxX, point[0]);
-      maxY = Math.max(maxY, point[1]);
-    });
-    return renderImage.Point.call(this, image, [minX + (maxX - minX) / 2, minY + (maxY - minY) / 2])
-  },
-  'MultiPoint': function(image, p, scale) {
-    // Can't use forEach here because we need to pass scale along
-    for (var i = 0, len = p.length; i < len; i++) {
-      renderImage.Point.call(this, image, p[i], scale);
+    'Point': function(p, scale) {
+      if (transform) {
+        p = transform(p);
+        this.arc(p[0], p[1], 8, 0, Math.PI * 2, true);
+      }
+      else {
+        this.arc(p[0], p[1], 8 / scale, 0, Math.PI * 2, true);
+      }
     }
-  },
-  'Point': function(image, p, scale) {
-    if (transform) {
-      p = transform(p);
-    }
-    this.drawImage(image, p[0] - image.width / 2, p[1] - image.height / 2);
-  }
-};
+  };
 
-var renderDot = {
-  'MultiPolygon': function(radius, mp) {
-    mp.forEach(renderDot.Polygon.bind(this, radius));
-  },
-  'Polygon': function(radius, p) {
-    renderDot.LineString.call(this, radius, p[0]);
-  },
-  'MultiLineString': function(radius, ml) {
-    ml.forEach(renderDot.LineString.bind(this, radius));
-  },
-  'LineString': function(radius, l) {
-    // put the point at the center
-    var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-    l.forEach(function(point) {
-      minX = Math.min(minX, point[0]);
-      minY = Math.min(minY, point[1]);
-      maxX = Math.max(maxX, point[0]);
-      maxY = Math.max(maxY, point[1]);
-    });
-    return renderDot.Point.call(this, radius, [minX + (maxX - minX) / 2, minY + (maxY - minY) / 2])
-  },
-  'MultiPoint': function(radius, p, scale) {
-    // Can't use forEach here because we need to pass scale along
-    for (var i = 0, len = p.length; i < len; i++) {
-      renderDot.Point.call(this, radius, p[i], scale);
-    }
-  },
-  'Point': function(radius, p) {
-    if (transform) {
-      p = transform(p);
-    }
-    this.arc(p[0], p[1], radius || 10, 0, Math.PI * 2, true);
-  }
-};
+  // TODO: where / why do we use this?
+  var roundPoint = function(point) {
+    return point.map(Math.round);
+  };
 
-var renderText = {
-  'MultiPolygon': function(text, mp) {
-    mp.forEach(renderText.Polygon.bind(this, text));
-  },
-  'Polygon': function(text, p) {
-    renderText.LineString.call(this, text, p[0]);
-  },
-  'MultiLineString': function(text, ml) {
-    ml.forEach(renderText.LineString.bind(this, text));
-  },
-  'LineString': function(text, l) {
+  // Functions to render dashed lines
+  // Many canvas implementations don't support the dash/lineDash property, so we do it by hand :\
+  // NOTE also lineDash is in the WHATWG HTML draft but not W3C:
+  // http://www.whatwg.org/specs/web-apps/current-work/multipage/the-canvas-element.html
+  var renderDashedPath = {
+    'MultiPolygon': function(dashArray, mp) {
+      mp.forEach(renderDashedPath.Polygon.bind(this, dashArray));
+    },
+    'Polygon': function(dashArray, p) {
+      p.forEach(renderDashedPath.LineString.bind(this, dashArray));
+    },
+    'MultiLineString': function(dashArray, ml) {
+      ml.forEach(renderDashedPath.LineString.bind(this, dashArray));
+    },
 
-    // we support line and point, point is default
-    if (text.placement === "line") {
-      this.textAlign = "left";
+    'LineString': function(dashArray, l, offset) {
+      // if there's no dashArray, just go render a solid line
+      if (!dashArray) {
+        return renderPath.LineString.call(this, l);
+      }
 
-      var totalLength = 0;
-      var segmentLengths = [];
+      offset = offset || 0;
 
+      // don't render segments less than this length (in px)
+      // for best fidelity, this should be at least 1, but not much higher
+      var minSegmentLength = 2;
+
+      // round off the start and end points to get as close as we can to drawing on pixel boundaries
+      // loop through line combining segments until they match the minimum length
+      var start = roundPoint(transform(l[0]));
       for (var i = 1, len = l.length; i < len; i++) {
-        var start = transform(l[i - 1]);
-            end = transform(l[i]),
+        var end = roundPoint(transform(l[i])),
             dx = end[0] - start[0];
             dy = end[1] - start[1];
             lineLength = Math.sqrt(dx * dx + dy * dy);
 
-        totalLength += lineLength;
-        segmentLengths.push(lineLength);
-      }
-
-      var closedShape = l[0][0] === l[len - 1][0] && l[0][1] === l[len - 1][1];
-
-      // NOTE: should we really bail here if there's not enough room on the line to write the text?
-      // maybe this should be an option (on by default)
-      var textLength = this.measureText(text.text).width;
-      if (totalLength < textLength) {
-        return;
-      }
-
-      // determine distance along line to start placing text
-      var startPoint = 0;
-      // TODO: support BIDI text (right now end = right and start = left)
-      if (text.align === "end" || text.align === "right") {
-        startPoint = totalLength - textLength;
-      }
-      else if (text.align === "center" || text.align === "middle" || !text.align) {
-        startPoint = totalLength / 2 - textLength / 2;
-      }
-
-      // these operations may be destructive to the text object, so save old values here
-      // TODO: maybe we should make a new object that uses the text argument as its prototype?
-      var fullText = text.text;
-      var originalXOffset = 0;
-      if (text.offset) {
-        originalXOffset = text.offset.x || 0;
-        startPoint += originalXOffset;
-        text.offset.x = 0;
-
-        // if the line represents a closed shape, loop startPoint around the line
-        if (closedShape) {
-          while (startPoint < 0) {
-            startPoint += totalLength;
-          }
-
-          while (startPoint > totalLength) {
-            startPoint -= totalLength;
-          }
+        // only draw segments of 1px or greater
+        if (lineLength >= minSegmentLength) {
+          var angle = Math.atan2(dy, dx);
+          offset = renderDashedPath._screenLine.call(this, dashArray, start, end, lineLength, angle, offset);
+          start = end;
         }
       }
 
-      var segmentLengthsTotal = 0;
+    },
 
-      for (var i = 0, len = segmentLengths.length; i < len; i++) {
-        var segmentLength = segmentLengths[i];
-        if (segmentLengthsTotal + segmentLength >= startPoint || i === len - 1) {
-          var segmentDistance = startPoint - segmentLengthsTotal;
+    // TODO: What does this do?
+    _screenLine: function(dashArray, start, end, realLength, angle, offset) {
+      // we're gonna do some transforms
+      this.save();
 
-          var start = transform(l[i]),
-              end = transform(l[i + 1]),
-              dx = end[0] - start[0],
-              dy = end[1] - start[1],
-              angle = Math.atan2(dy, dx),
-              centerPoint = [segmentDistance * Math.cos(angle) + start[0], start[1] + segmentDistance * Math.sin(angle)];
+      // move the line out by half a pixel for more crisp 1px drawing
+      var yOffset = -0.5;
 
-          // keep street names from going upside-down
-          var flippedText = false;
-          var flippedMinus = false;
-          if (angle > 0.5 * Math.PI) {
-            angle -= Math.PI;
-            flippedText = true;
-            flippedMinus = true;
-          }
-          else if (angle < -0.5 * Math.PI) {
-            angle += Math.PI;
-            flippedText = true;
-          }
+      // In order to reduce artifacts of trying to draw fractions of a pixel,
+      // only draw even pixels worth of length
+      var length = Math.floor(realLength);
 
-          this.save();
-          this.translate(centerPoint[0], centerPoint[1]);
-          this.rotate(angle);
+      // Skip zero length/less-than-one length lines
+      if (length === 0) {
+        return offset;
+      }
 
-          if (MIGURSKI) {
-            var textPixels = 0;
-            var resetIndex = 0;
-            var segmentOffset = 0;
-            for (var j = 0, jLen = fullText.length; j < jLen; j++) {
-              // GO BACKWARDS FOR FLIPPED TEXT
-              if (flippedText) {
+      // decimal offset is left over from refraining from drawing fractions of a pixel on a previous segment
+      // (see where the length is floor()'d above)
+      // We'll eventually move the start point back by the fractional offset to account for what we
+      // didn't draw in the previous segment (we potentially underdraw because we floor()'d the length).
+      var intOffset = Math.ceil(offset);
+      var decOffset = offset - intOffset;
+      offset = intOffset;
 
-                if (segmentOffset + segmentDistance + textPixels > segmentLength && (i < len - 1 || closedShape)) {
-                  // TODO: Potentially add some spacing if the angle causes the text top to bend "in"
-                  segmentOffset = (segmentOffset + segmentDistance + textPixels) - segmentLength;
-                  i = (i + 1) % len;
-                  segmentLength = segmentLengths[i];
-                  segmentDistance = 0;
-                  var start = transform(l[i]),
-                      end = transform(l[i + 1]),
-                      dx = end[0] - start[0],
-                      dy = end[1] - start[1],
-                      angle = Math.atan2(dy, dx);
+      // transform the context so we can simplify the work by pretending to draw a straight line
+      this.translate(start[0], start[1]);
+      this.rotate(angle);
 
-                  // keep street names from going upside-down
-                  if (flippedText) {
-                    if (flippedMinus) {
-                      angle -= Math.PI;
-                    }
-                    else {
-                      angle += Math.PI;
-                    }
-                  }
+      // Move the start point back by the fractional offset (see deeper description above)
+      this.moveTo(decOffset, yOffset);
 
-                  this.restore();
-                  this.save();
-                  this.translate(start[0], start[1]);
-                  this.rotate(angle);
-                  textPixels = 0;
-                  resetIndex = j;
-                }
+      var dashCount = dashArray.length;
+      var dashIndex = 0;
+      // Move the start point by the integer offset (the fractional bit is already accounted for above)
+      var x = offset || 0;
+      // keep track of how much of the pattern we drew (used to offset the next segment)
+      var patternDistance = 0;
+      var draw = true;
 
-                var textIndex = jLen - 1 - j;
-                textPixels = this.measureText(fullText.slice(textIndex, jLen - resetIndex)).width;
+      while (x < length) {
+        // reset the pattern distance when we loop back to the start of the dash array
+        if (dashIndex === 0) {
+          patternDistance = 0;
+        }
 
-                text.text = fullText[textIndex];
-                renderText.Point.call(this, text, [-(segmentOffset + textPixels), 0], true);
-              }
-              else {
+        // get the distance of this dash
+        var dashLength = dashArray[dashIndex];
+        dashIndex = (dashIndex + 1) % dashCount;
+        x += dashLength;
+        patternDistance += dashLength;
 
-                var textIndex = j;
-                var textResetIndex = resetIndex;
-                if (j > 0) {
-                  textPixels = this.measureText(fullText.slice(resetIndex, j)).width;
-                }
+        // if we are about to draw past the end of the segment, don't
+        if (x > length) {
+          patternDistance += length - x;
+          x = length;
+        }
 
-                if (segmentOffset + segmentDistance + textPixels > segmentLength && (i < len - 1 || closedShape)) {
-                  // TODO: Potentially add some spacing if the angle causes the text top to bend "in"
-                  segmentOffset = (segmentOffset + segmentDistance + textPixels) - segmentLength;
-                  i = (i + 1) % len;
-                  segmentLength = segmentLengths[i];
-                  segmentDistance = 0;
-                  var start = transform(l[i]),
-                      end = transform(l[i + 1]),
-                      dx = end[0] - start[0],
-                      dy = end[1] - start[1],
-                      angle = Math.atan2(dy, dx);
-
-                  this.restore();
-                  this.save();
-                  this.translate(start[0], start[1]);
-                  this.rotate(angle);
-                  textPixels = 0;
-                  resetIndex = j;
-                }
-
-                text.text = fullText[textIndex];
-                renderText.Point.call(this, text, [segmentOffset + textPixels, 0], true);
-              }
-            }
+        // only draw once we've moved past the offset
+        if (x > 0) {
+          if (draw) {
+            this.lineTo(x, yOffset);
           }
           else {
-            renderText.Point.call(this, text, [0, 0], true);
+            this.moveTo(x, yOffset);
           }
-
-          this.restore();
-          break;
         }
-        segmentLengthsTotal += segmentLength;
+        draw = !draw;
       }
+      // Add the fractional extra distance that we didn't draw back in
+      patternDistance += realLength - length;
 
-      // repair text object before returning
-      text.text = fullText;
-      text.offset.x = originalXOffset;
+      this.restore();
+      return -patternDistance;
+    },
+    'MultiPoint': function(dashArray, p, scale) {
+      // Can't use forEach here because we need to pass scale along
+      for (var i = 0, len = p.length; i < len; i++) {
+        renderDashedPath.Point.call(this, null, p[i], scale);
+      }
+    },
+    'Point': function(dashArray, p, scale) {
+      if (transform) {
+        p = transform(p);
+        this.arc(p[0], p[1], 8, 0, Math.PI * 2, true);
+      }
+      else {
+        this.arc(p[0], p[1], 8 / scale, 0, Math.PI * 2, true);
+      }
     }
-    else {
+  };
+
+  var renderImage = {
+    'MultiPolygon': function(image, mp) {
+      mp.forEach(renderImage.Polygon.bind(this, image));
+    },
+    'Polygon': function(image, p) {
+      renderImage.LineString.call(this, image, p[0]);
+    },
+    'MultiLineString': function(image, ml) {
+      ml.forEach(renderImage.LineString.bind(this, image));
+    },
+    'LineString': function(image, l) {
       // put the point at the center
       var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
       l.forEach(function(point) {
@@ -611,28 +359,295 @@ var renderText = {
         maxX = Math.max(maxX, point[0]);
         maxY = Math.max(maxY, point[1]);
       });
-      return renderText.Point.call(this, text, [minX + (maxX - minX) / 2, minY + (maxY - minY) / 2])
+      return renderImage.Point.call(this, image, [minX + (maxX - minX) / 2, minY + (maxY - minY) / 2])
+    },
+    'MultiPoint': function(image, p, scale) {
+      // Can't use forEach here because we need to pass scale along
+      for (var i = 0, len = p.length; i < len; i++) {
+        renderImage.Point.call(this, image, p[i], scale);
+      }
+    },
+    'Point': function(image, p, scale) {
+      if (transform) {
+        p = transform(p);
+      }
+      this.drawImage(image, p[0] - image.width / 2, p[1] - image.height / 2);
     }
-  },
-  'MultiPoint': function(text, p, scale) {
-    // Can't use forEach here because we need to pass scale along
-    for (var i = 0, len = p.length; i < len; i++) {
-      renderText.Point.call(this, radius, p[i], scale);
+  };
+
+  var renderDot = {
+    'MultiPolygon': function(radius, mp) {
+      mp.forEach(renderDot.Polygon.bind(this, radius));
+    },
+    'Polygon': function(radius, p) {
+      renderDot.LineString.call(this, radius, p[0]);
+    },
+    'MultiLineString': function(radius, ml) {
+      ml.forEach(renderDot.LineString.bind(this, radius));
+    },
+    'LineString': function(radius, l) {
+      // put the point at the center
+      var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+      l.forEach(function(point) {
+        minX = Math.min(minX, point[0]);
+        minY = Math.min(minY, point[1]);
+        maxX = Math.max(maxX, point[0]);
+        maxY = Math.max(maxY, point[1]);
+      });
+      return renderDot.Point.call(this, radius, [minX + (maxX - minX) / 2, minY + (maxY - minY) / 2])
+    },
+    'MultiPoint': function(radius, p, scale) {
+      // Can't use forEach here because we need to pass scale along
+      for (var i = 0, len = p.length; i < len; i++) {
+        renderDot.Point.call(this, radius, p[i], scale);
+      }
+    },
+    'Point': function(radius, p) {
+      if (transform) {
+        p = transform(p);
+      }
+      this.arc(p[0], p[1], radius || 10, 0, Math.PI * 2, true);
     }
-  },
-  'Point': function(text, p, preTransformed) {
-    if (transform && !preTransformed) {
-      p = transform(p);
+  };
+
+  var renderText = {
+    'MultiPolygon': function(text, mp) {
+      mp.forEach(renderText.Polygon.bind(this, text));
+    },
+    'Polygon': function(text, p) {
+      renderText.LineString.call(this, text, p[0]);
+    },
+    'MultiLineString': function(text, ml) {
+      ml.forEach(renderText.LineString.bind(this, text));
+    },
+    'LineString': function(text, l) {
+
+      // we support line and point, point is default
+      if (text.placement === "line") {
+        this.textAlign = "left";
+
+        var totalLength = 0;
+        var segmentLengths = [];
+
+        for (var i = 1, len = l.length; i < len; i++) {
+          var start = transform(l[i - 1]);
+              end = transform(l[i]),
+              dx = end[0] - start[0];
+              dy = end[1] - start[1];
+              lineLength = Math.sqrt(dx * dx + dy * dy);
+
+          totalLength += lineLength;
+          segmentLengths.push(lineLength);
+        }
+
+        var closedShape = l[0][0] === l[len - 1][0] && l[0][1] === l[len - 1][1];
+
+        // NOTE: should we really bail here if there's not enough room on the line to write the text?
+        // maybe this should be an option (on by default)
+        var textLength = this.measureText(text.text).width;
+        if (totalLength < textLength) {
+          return;
+        }
+
+        // determine distance along line to start placing text
+        var startPoint = 0;
+        // TODO: support BIDI text (right now end = right and start = left)
+        if (text.align === "end" || text.align === "right") {
+          startPoint = totalLength - textLength;
+        }
+        else if (text.align === "center" || text.align === "middle" || !text.align) {
+          startPoint = totalLength / 2 - textLength / 2;
+        }
+
+        // these operations may be destructive to the text object, so save old values here
+        // TODO: maybe we should make a new object that uses the text argument as its prototype?
+        var fullText = text.text;
+        var originalXOffset = 0;
+        if (text.offset) {
+          originalXOffset = text.offset.x || 0;
+          startPoint += originalXOffset;
+          text.offset.x = 0;
+
+          // if the line represents a closed shape, loop startPoint around the line
+          if (closedShape) {
+            while (startPoint < 0) {
+              startPoint += totalLength;
+            }
+
+            while (startPoint > totalLength) {
+              startPoint -= totalLength;
+            }
+          }
+        }
+
+        var segmentLengthsTotal = 0;
+
+        for (var i = 0, len = segmentLengths.length; i < len; i++) {
+          var segmentLength = segmentLengths[i];
+          if (segmentLengthsTotal + segmentLength >= startPoint || i === len - 1) {
+            var segmentDistance = startPoint - segmentLengthsTotal;
+
+            var start = transform(l[i]),
+                end = transform(l[i + 1]),
+                dx = end[0] - start[0],
+                dy = end[1] - start[1],
+                angle = Math.atan2(dy, dx),
+                centerPoint = [segmentDistance * Math.cos(angle) + start[0], start[1] + segmentDistance * Math.sin(angle)];
+
+            // keep street names from going upside-down
+            var flippedText = false;
+            var flippedMinus = false;
+            if (angle > 0.5 * Math.PI) {
+              angle -= Math.PI;
+              flippedText = true;
+              flippedMinus = true;
+            }
+            else if (angle < -0.5 * Math.PI) {
+              angle += Math.PI;
+              flippedText = true;
+            }
+
+            this.save();
+            this.translate(centerPoint[0], centerPoint[1]);
+            this.rotate(angle);
+
+            if (MIGURSKI) {
+              var textPixels = 0;
+              var resetIndex = 0;
+              var segmentOffset = 0;
+              for (var j = 0, jLen = fullText.length; j < jLen; j++) {
+                // GO BACKWARDS FOR FLIPPED TEXT
+                if (flippedText) {
+
+                  if (segmentOffset + segmentDistance + textPixels > segmentLength && (i < len - 1 || closedShape)) {
+                    // TODO: Potentially add some spacing if the angle causes the text top to bend "in"
+                    segmentOffset = (segmentOffset + segmentDistance + textPixels) - segmentLength;
+                    i = (i + 1) % len;
+                    segmentLength = segmentLengths[i];
+                    segmentDistance = 0;
+                    var start = transform(l[i]),
+                        end = transform(l[i + 1]),
+                        dx = end[0] - start[0],
+                        dy = end[1] - start[1],
+                        angle = Math.atan2(dy, dx);
+
+                    // keep street names from going upside-down
+                    if (flippedText) {
+                      if (flippedMinus) {
+                        angle -= Math.PI;
+                      }
+                      else {
+                        angle += Math.PI;
+                      }
+                    }
+
+                    this.restore();
+                    this.save();
+                    this.translate(start[0], start[1]);
+                    this.rotate(angle);
+                    textPixels = 0;
+                    resetIndex = j;
+                  }
+
+                  var textIndex = jLen - 1 - j;
+                  textPixels = this.measureText(fullText.slice(textIndex, jLen - resetIndex)).width;
+
+                  text.text = fullText[textIndex];
+                  renderText.Point.call(this, text, [-(segmentOffset + textPixels), 0], true);
+                }
+                else {
+
+                  var textIndex = j;
+                  var textResetIndex = resetIndex;
+                  if (j > 0) {
+                    textPixels = this.measureText(fullText.slice(resetIndex, j)).width;
+                  }
+
+                  if (segmentOffset + segmentDistance + textPixels > segmentLength && (i < len - 1 || closedShape)) {
+                    // TODO: Potentially add some spacing if the angle causes the text top to bend "in"
+                    segmentOffset = (segmentOffset + segmentDistance + textPixels) - segmentLength;
+                    i = (i + 1) % len;
+                    segmentLength = segmentLengths[i];
+                    segmentDistance = 0;
+                    var start = transform(l[i]),
+                        end = transform(l[i + 1]),
+                        dx = end[0] - start[0],
+                        dy = end[1] - start[1],
+                        angle = Math.atan2(dy, dx);
+
+                    this.restore();
+                    this.save();
+                    this.translate(start[0], start[1]);
+                    this.rotate(angle);
+                    textPixels = 0;
+                    resetIndex = j;
+                  }
+
+                  text.text = fullText[textIndex];
+                  renderText.Point.call(this, text, [segmentOffset + textPixels, 0], true);
+                }
+              }
+            }
+            else {
+              renderText.Point.call(this, text, [0, 0], true);
+            }
+
+            this.restore();
+            break;
+          }
+          segmentLengthsTotal += segmentLength;
+        }
+
+        // repair text object before returning
+        text.text = fullText;
+        text.offset.x = originalXOffset;
+      }
+      else {
+        // put the point at the center
+        var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+        l.forEach(function(point) {
+          minX = Math.min(minX, point[0]);
+          minY = Math.min(minY, point[1]);
+          maxX = Math.max(maxX, point[0]);
+          maxY = Math.max(maxY, point[1]);
+        });
+        return renderText.Point.call(this, text, [minX + (maxX - minX) / 2, minY + (maxY - minY) / 2])
+      }
+    },
+    'MultiPoint': function(text, p, scale) {
+      // Can't use forEach here because we need to pass scale along
+      for (var i = 0, len = p.length; i < len; i++) {
+        renderText.Point.call(this, radius, p[i], scale);
+      }
+    },
+    'Point': function(text, p, preTransformed) {
+      if (transform && !preTransformed) {
+        p = transform(p);
+      }
+      var x = p[0] + (text.offset ? text.offset.x : 0);
+      var y = p[1] + (text.offset ? text.offset.y : 0);
+      var textMethod = text.stroke ? "strokeText" : "fillText";
+      this[textMethod](text.text, x, y);
     }
-    var x = p[0] + (text.offset ? text.offset.x : 0);
-    var y = p[1] + (text.offset ? text.offset.y : 0);
-    var textMethod = text.stroke ? "strokeText" : "fillText";
-    this[textMethod](text.text, x, y);
-  }
-};
+  };
+
+  return {
+    renderPath: renderPath,
+    renderDashedPath: renderDashedPath,
+    renderImage: renderImage,
+    renderText: renderText,
+    renderDot: renderDot
+  };
+}
 
 // var didATile = false;
-var cartoImageRenderer = function (ctx, scale, layers, styles, zoom, minX, maxX, minY) {
+var cartoImageRenderer = function (ctx, scale, layers, styles, zoom, minX, maxX, minY, transform) {
+  var suite = makeRenderers(transform);
+  var renderPath = suite.renderPath;
+  var renderDashedPath = suite.renderDashedPath;
+  var renderImage = suite.renderImage;
+  var renderText = suite.renderText;
+  var renderDot = suite.renderDot;
 
   styles.forEach(function(style) {
     if (cartoSelectorIsMatch(style, null, null, zoom)) {
@@ -1027,7 +1042,10 @@ var cartoImageRenderer = function (ctx, scale, layers, styles, zoom, minX, maxX,
 };
 
 
-var cartoGridRenderer = function (ctx, scale, layers, styles, zoom) {
+var cartoGridRenderer = function (ctx, scale, layers, styles, zoom, transform) {
+  var suite = makeRenderers(transform);
+  var renderPath = suite.renderPath;
+
   var intColor = 1; // color zero is black/empty; so start with 1
   var colorIndex = ['']; // make room for black/empty
 


### PR DESCRIPTION
There were a couple of things causing us to hang onto references to the full dataset when rendering UTFGrids. For some of our tiles, that's a pretty large amount of data.

The change looks huge because some re-scoping involved more indentation for a large block of code.

/cc @hampelm 
