### PR TITLE
5012 text halo radius

### DIFF
--- a/lib/cartoRenderer.js
+++ b/lib/cartoRenderer.js
@@ -1024,7 +1024,7 @@ var cartoImageRenderer = function (ctx, scale, layers, styles, zoom, minX, maxX,
                 if (instanceStyle["text-halo-fill"]) {
                   ctx.strokeStyle = instanceStyle["text-halo-fill"].toString();
                   if (instanceStyle["text-halo-radius"]) {
-                    ctx.lineWidth = instanceStyle["text-halo-radius"].value * 2;
+                    ctx.lineWidth = parseInt(instanceStyle["text-halo-radius"] || 1) * 2;
                   }
 
                   // definitely DON'T leave this set to miter :P

--- a/lib/cartoRenderer.js
+++ b/lib/cartoRenderer.js
@@ -776,6 +776,12 @@ var cartoImageRenderer = function (ctx, scale, layers, styles, zoom, minX, maxX,
                 }
 
                 collapsedStyle[rule.instance][rule.name] = value;
+                
+                // Handle text queries for labels
+                // We cannot stringify these because they include special formatting
+                if (rule.value.is == 'propertyLookup') {
+                  collapsedStyle[rule.instance][rule.name] = rule.value
+                }
               }
 
               collapsedStylesBySignature[signatureString] = collapsedStyle;

--- a/lib/cartoRenderer.js
+++ b/lib/cartoRenderer.js
@@ -1430,7 +1430,8 @@ exports.processStyles = function(styles, assetsPath) {
           // Don't re-convert numbers or strings.
           if (!(typeof filter.val === 'number' || typeof filter.val === 'string')) {
             // If val doesn't have an explicit value, get one via toString.
-            filter.val = filter.val.value || filter.val.toString();
+            // Also, lets not make 0 a string
+            filter.val = filter.val.value === 0 ? filter.val.value : filter.val.value || filter.val.toString();
           }
         });
       }


### PR DESCRIPTION
`text-halo-radius` was unresponsive due to `.value`. Corrected with `parseInt()` and confirmed using tile demos. 